### PR TITLE
Revamp filtering in tab 2

### DIFF
--- a/tab2.py
+++ b/tab2.py
@@ -64,26 +64,11 @@ def main(argv = None) -> None:
             st.success(f"Loaded results from {loaded_from_which_files}!")
 
     ############################################################################
-            show_previews_header = st.subheader("View Result", divider = DIV_COLOR)
-            frag_preview_text = st.markdown("Data of the fragment-centric dataframe:")
+            st.subheader("View Result", divider=DIV_COLOR)
+
             N_ion = st.checkbox("Show non-annotated fragments",
                                 value=False,
                                 help="Whether or not to show non-annotated fragments in the output.")
-            if N_ion:
-                frag_preview = st.dataframe(st.session_state["dataframes"][0], height = 400, use_container_width = True)
-            else:
-                frag_preview = st.dataframe(st.session_state["dataframes"][0].dropna(subset = "frag_seq"), height = 400, use_container_width = True)
-
-            spec_preview_text = st.markdown("Data of the spectrum-centric dataframe:")
-            spec_preview = st.dataframe(st.session_state["dataframes"][1], height = 400, use_container_width = True)
-            modify = st.checkbox("Filter data", value=False, help="Display filter options")
-            if modify:
-                tmp_frag, tmp_spec = filter_dataframe(st.session_state["dataframes"][0], st.session_state["dataframes"][1], 'fragment')
-                st.session_state["spec_center_filtered"], st.session_state["frag_center_filtered"] = filter_dataframe(tmp_spec, tmp_frag, 'spectrum')
-            else:
-                st.session_state["frag_center_filtered"] = st.session_state["dataframes"][0]
-                st.session_state["spec_center_filtered"] = st.session_state["dataframes"][1]
-
             ion_filter_param = [N_ion,
                                 "a" in st.session_state["selected_ions_nterm"],
                                 "b" in st.session_state["selected_ions_nterm"],
@@ -98,8 +83,19 @@ def main(argv = None) -> None:
                                 "z+1" in st.session_state["selected_ions_cterm"],
                                 "z+2" in st.session_state["selected_ions_cterm"],
                                 "z+3" in st.session_state["selected_ions_cterm"]]
+
             st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"] = filter_dataframes(
-                [st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"]], ion_filter_param)
+                st.session_state["dataframes"], ion_filter_param)
+
+            modify = st.checkbox("Filter data", value=False, help="Display filter options")
+            if modify:
+                tmp_frag, tmp_spec = filter_dataframe(st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"], 'fragment')
+                st.session_state["spec_center_filtered"], st.session_state["frag_center_filtered"] = filter_dataframe(tmp_spec, tmp_frag, 'spectrum')
+
+            st.markdown("Data of the fragment-centric dataframe:")
+            st.dataframe(st.session_state["frag_center_filtered"], height=400, use_container_width=True)
+            st.markdown("Data of the spectrum-centric dataframe:")
+            st.dataframe(st.session_state["spec_center_filtered"], height=400, use_container_width=True)
 
     ############################################################################
 

--- a/tab2.py
+++ b/tab2.py
@@ -66,99 +66,23 @@ def main(argv = None) -> None:
     ############################################################################
             show_previews_header = st.subheader("View Result", divider = DIV_COLOR)
             frag_preview_text = st.markdown("Data of the fragment-centric dataframe:")
-            frag_preview_include_na = st.checkbox("Show non-annotated fragments",
-                                                  value = False,
-                                                  help = "Whether or not to show non-annotated fragments in the dataframe.")
-            if frag_preview_include_na:
+            N_ion = st.checkbox("Show non-annotated fragments",
+                                value=False,
+                                help="Whether or not to show non-annotated fragments in the output.")
+            if N_ion:
                 frag_preview = st.dataframe(st.session_state["dataframes"][0], height = 400, use_container_width = True)
             else:
                 frag_preview = st.dataframe(st.session_state["dataframes"][0].dropna(subset = "frag_seq"), height = 400, use_container_width = True)
-            modify_frag = st.checkbox("Filter fragment-centric dataframe",
-                                      value = False,
-                                      help = "Display filter option for the fragment-centric dataframe.")
-            st.session_state["frag_center_filtered"] = filter_dataframe(st.session_state["dataframes"][0], modify_frag)
+
             spec_preview_text = st.markdown("Data of the spectrum-centric dataframe:")
             spec_preview = st.dataframe(st.session_state["dataframes"][1], height = 400, use_container_width = True)
-            modify_spec = st.checkbox("Filter spectrum-centric dataframe",
-                                      value = False,
-                                      help = "Display filter option for the spectrum-centric dataframe.")
-            st.session_state["spec_center_filtered"] = filter_dataframe(st.session_state["dataframes"][1], modify_spec)
-
-    ############################################################################
-            filter_dfs_header = st.subheader("Filter Results", divider = DIV_COLOR)
-            filter_dfs_desc_text = st.markdown("Results can be further filtered with the filtering options below (optional).")
-
-            # START filtering options
-            filter_select_col1, filter_select_col2 = st.columns(2)
-
-            with filter_select_col1:
-                istart_seq_length = st.number_input("Minimum peptide sequence length:",
-                                                    min_value = 0,
-                                                    max_value = 1000,
-                                                    value = 0,
-                                                    step = 1,
-                                                    help = "For \"Spectrum-centric Statistics\" only spectra with peptides withing range are considered.")
-
-                istart_frag_length = st.number_input("Minimum fragment ion sequence lenght:",
-                                                     min_value = 0,
-                                                     max_value = 1000,
-                                                     value = 0,
-                                                     step = 1,
-                                                     help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-                istart_mz = st.number_input("Minimum m/z for internal fragments:",
-                                            min_value = 0,
-                                            max_value = 10000,
-                                            value = 0,
-                                            step = 1,
-                                            help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-                istart_int = st.number_input("Minimum intensity for internal fragments:",
-                                             min_value = 0,
-                                             max_value = 1000000,
-                                             value = 0,
-                                             step = 1,
-                                             help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-            with filter_select_col2:
-                iend_seq_length = st.number_input("Maximum peptide sequence length:",
-                                                  min_value = 0,
-                                                  max_value = 1000,
-                                                  value = 1000,
-                                                  step = 1,
-                                                  help = "For \"Spectrum-centric Statistics\" only spectra with peptides withing range are considered.")
-
-                iend_frag_length = st.number_input("Maximum fragment ion sequence lenght:",
-                                                   min_value = 0,
-                                                   max_value = 1000,
-                                                   value = 1000,
-                                                   step = 1,
-                                                   help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-                iend_mz = st.number_input("Maximum m/z for internal fragments:",
-                                          min_value = 0,
-                                          max_value = 10000,
-                                          value = 10000,
-                                          step = 1,
-                                          help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-                iend_int = st.number_input("Maximum intensity for internal fragments:",
-                                           min_value = 0,
-                                           max_value = 1000000,
-                                           value = 1000000,
-                                           step = 1,
-                                           help = "For \"Fragment-centric Statistics\" only fragments within range are considered.")
-
-            start_seq_length = istart_seq_length if istart_seq_length < iend_seq_length else iend_seq_length
-            end_seq_length = iend_seq_length if iend_seq_length > istart_seq_length else istart_seq_length
-            start_frag_length = istart_frag_length if istart_frag_length < iend_frag_length else iend_frag_length
-            end_frag_length = iend_frag_length if iend_frag_length > istart_frag_length else istart_frag_length
-            start_mz = istart_mz if istart_mz < iend_mz else iend_mz
-            end_mz = iend_mz if iend_mz > istart_mz else istart_mz
-            start_int = istart_int if istart_int < iend_int else iend_int
-            end_int = iend_int if iend_int > istart_int else istart_int
-
-            N_ion = st.checkbox("Show non-annotated ions", value = True)
+            modify = st.checkbox("Filter data", value=False, help="Display filter options")
+            if modify:
+                st.session_state["frag_center_filtered"] = filter_dataframe(st.session_state["dataframes"][0], 'spectrum')
+                st.session_state["spec_center_filtered"] = filter_dataframe(st.session_state["dataframes"][1], 'fragment')
+            else:
+                st.session_state["frag_center_filtered"] = st.session_state["dataframes"][0]
+                st.session_state["spec_center_filtered"] = st.session_state["dataframes"][1]
 
             ion_filter_param = [N_ion,
                                 "a" in st.session_state["selected_ions_nterm"],
@@ -169,25 +93,16 @@ def main(argv = None) -> None:
                                 "c+1" in st.session_state["selected_ions_nterm"],
                                 "x" in st.session_state["selected_ions_cterm"],
                                 "y" in st.session_state["selected_ions_cterm"],
-                                False, # z ions, this is a relict
+                                False,  # z ions, this is a relict
                                 "zdot" in st.session_state["selected_ions_cterm"],
                                 "z+1" in st.session_state["selected_ions_cterm"],
                                 "z+2" in st.session_state["selected_ions_cterm"],
                                 "z+3" in st.session_state["selected_ions_cterm"]]
-            # END filtering options
-
-            filtered_fragments_df, filtered_spectra_df = filter_dataframes([st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"]],
-                                                                           start_seq_length,
-                                                                           end_seq_length,
-                                                                           start_frag_length,
-                                                                           end_frag_length,
-                                                                           start_mz,
-                                                                           end_mz,
-                                                                           start_int,
-                                                                           end_int,
-                                                                           ion_filter_param)
+            st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"] = filter_dataframes(
+                [st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"]], ion_filter_param)
 
     ############################################################################
+
             frag_center_stats_header = st.subheader("Fragment-centric Statistics", divider = DIV_COLOR)
             frag_center_stats_desc = st.markdown("Fragment-centric stats description.")
 
@@ -195,28 +110,28 @@ def main(argv = None) -> None:
 
             with frag_center_plot_col1_1:
                 plot1_title = st.markdown("**Distribution of Ion Types**")
-                plot1 = st.plotly_chart(common_type_hist(filtered_fragments_df), use_container_width = True)
+                plot1 = st.plotly_chart(common_type_hist(st.session_state["frag_center_filtered"]), use_container_width = True)
                 plot1_caption = st.markdown(f"**Figure 1:** Histogram illustrating the frequency distribution of ion types present in the dataset.")
 
             with frag_center_plot_col1_2:
                 plot2_title = st.markdown("**Ion Type Proportions**")
-                plot2 = st.plotly_chart(common_type_pie(filtered_fragments_df), use_container_width = True)
+                plot2 = st.plotly_chart(common_type_pie(st.session_state["frag_center_filtered"]), use_container_width = True)
                 plot2_caption = st.markdown(f"**Figure 2:** Pie chart displaying the proportional composition of ion types within the dataset.")
 
             plot3_title = st.markdown("**Distribution of m/z Values Across Ion Types**")
-            plot3 = st.plotly_chart(mz_dist_ion_type(filtered_fragments_df), use_container_width = True)
+            plot3 = st.plotly_chart(mz_dist_ion_type(st.session_state["frag_center_filtered"]), use_container_width = True)
             plot3_caption = st.markdown(f"**Figure 3:** Histogram depicting the distribution of mass-to-charge ratio (m/z) values across different ion types.")
 
             frag_center_plot_col3_1, frag_center_plot_col3_2 = st.columns(2)
 
             with frag_center_plot_col3_1:
                 plot4_title = st.markdown("**Distribution of the Log Intensity**")
-                plot4 = st.plotly_chart(rel_ion_intens_perc(filtered_fragments_df), use_container_width = True)
+                plot4 = st.plotly_chart(rel_ion_intens_perc(st.session_state["frag_center_filtered"]), use_container_width = True)
                 plot4_caption = st.markdown(f"**Figure 4:** Distribution of log-transformed intensity values.")
 
             with frag_center_plot_col3_2:
                 plot5_title = st.markdown("**Relative Log Intensities**")
-                plot5 = st.plotly_chart(rel_ion_intens_ridge(filtered_fragments_df), use_container_width = True)
+                plot5 = st.plotly_chart(rel_ion_intens_ridge(st.session_state["frag_center_filtered"]), use_container_width = True)
                 plot5_caption = st.markdown(f"**Figure 5:** Distribution of log-transformed intensities relative to their respective scales.")
 
     ############################################################################
@@ -227,12 +142,12 @@ def main(argv = None) -> None:
 
             with spec_center_plot_col1_1:
                 plot6_title = st.markdown("**Ion Type Distribution Per Spectra**")
-                plot6 = st.plotly_chart(per_spec_ion_type(filtered_spectra_df), use_container_width = True)
+                plot6 = st.plotly_chart(per_spec_ion_type(st.session_state["spec_center_filtered"]), use_container_width = True)
                 plot6_caption = st.markdown(f"**Figure 6:** Distribution of ion types within each spectrum, providing insights into the diversity and abundance of ions detected across the dataset.")
 
             with spec_center_plot_col1_2:
                 plot7_title = st.markdown("**Log Intensities:**")
-                plot7 = st.plotly_chart(per_spec_ion_intens(filtered_spectra_df), use_container_width = True)
+                plot7 = st.plotly_chart(per_spec_ion_intens(st.session_state["spec_center_filtered"]), use_container_width = True)
                 plot7_caption = st.markdown(f"**Figure 7:** caption.")
 
             plot8_title = st.markdown("**Logo view of internal fragments:**")
@@ -246,8 +161,8 @@ def main(argv = None) -> None:
                 p8_min_length_logo, p8_max_length_logo = st.select_slider("Peptide sequence lenght:",
                                                                           options = range(0, 21),
                                                                           value = (0, 20))
-            plot8 = st.pyplot(logo_of_fraction(filtered_spectra_df,
-                                               filtered_fragments_df,
+            plot8 = st.pyplot(logo_of_fraction(st.session_state["spec_center_filtered"],
+                                               st.session_state["frag_center_filtered"],
                                                plot8_topn,
                                                p8_max_length_logo,
                                                p8_min_length_logo))

--- a/tab2.py
+++ b/tab2.py
@@ -78,8 +78,8 @@ def main(argv = None) -> None:
             spec_preview = st.dataframe(st.session_state["dataframes"][1], height = 400, use_container_width = True)
             modify = st.checkbox("Filter data", value=False, help="Display filter options")
             if modify:
-                st.session_state["frag_center_filtered"] = filter_dataframe(st.session_state["dataframes"][0], 'spectrum')
-                st.session_state["spec_center_filtered"] = filter_dataframe(st.session_state["dataframes"][1], 'fragment')
+                st.session_state["frag_center_filtered"] = filter_dataframe(st.session_state["dataframes"][0], 'fragment')
+                st.session_state["spec_center_filtered"] = filter_dataframe(st.session_state["dataframes"][1], 'spectrum')
             else:
                 st.session_state["frag_center_filtered"] = st.session_state["dataframes"][0]
                 st.session_state["spec_center_filtered"] = st.session_state["dataframes"][1]

--- a/tab2.py
+++ b/tab2.py
@@ -78,8 +78,8 @@ def main(argv = None) -> None:
             spec_preview = st.dataframe(st.session_state["dataframes"][1], height = 400, use_container_width = True)
             modify = st.checkbox("Filter data", value=False, help="Display filter options")
             if modify:
-                st.session_state["frag_center_filtered"] = filter_dataframe(st.session_state["dataframes"][0], 'fragment')
-                st.session_state["spec_center_filtered"] = filter_dataframe(st.session_state["dataframes"][1], 'spectrum')
+                tmp_frag, tmp_spec = filter_dataframe(st.session_state["dataframes"][0], st.session_state["dataframes"][1], 'fragment')
+                st.session_state["spec_center_filtered"], st.session_state["frag_center_filtered"] = filter_dataframe(tmp_spec, tmp_frag, 'spectrum')
             else:
                 st.session_state["frag_center_filtered"] = st.session_state["dataframes"][0]
                 st.session_state["spec_center_filtered"] = st.session_state["dataframes"][1]

--- a/util/tab2/filter.py
+++ b/util/tab2/filter.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python3
 
-import numpy as np
 import pandas as pd
 from typing import List
 
+
 def filter_dataframes(dataframes: List[pd.DataFrame],
-                      start_seq_length: int,
-                      end_seq_length: int,
-                      start_frag_len: int,
-                      end_frag_len: int,
-                      start_mz: float,
-                      end_mz: float,
-                      start_int: float,
-                      end_int: float,
                       ion_filter: List[bool]) -> List[pd.DataFrame]:
     """
     Filters dataframes based on the given values.
@@ -31,7 +23,4 @@ def filter_dataframes(dataframes: List[pd.DataFrame],
     # filter by ion type
     fragments_df = fragments_df[fragments_df["frag_code"].str.contains("|".join(ions_considered))]
 
-    fragments_df_filtered = fragments_df.query(f"frag_length > {start_frag_len} & frag_length < {end_frag_len} & frag_mz > {start_mz} & frag_mz < {end_mz} & frag_intensity > {start_int} & frag_intensity < {end_int}")
-    spectra_df_filtered = spectra_df.query(f"peptide_length > {start_seq_length} & peptide_length < {end_seq_length}")
-
-    return [fragments_df_filtered, spectra_df_filtered]
+    return [fragments_df, spectra_df]

--- a/util/tab2/filter2.py
+++ b/util/tab2/filter2.py
@@ -13,12 +13,13 @@ import pandas as pd
 import streamlit as st
 
 
-def filter_dataframe(df: pd.DataFrame, label: str) -> pd.DataFrame:
+def filter_dataframe(df: pd.DataFrame, other: pd.DataFrame, label: str) -> pd.DataFrame:
     """
     Adds a UI on top of a dataframe to let viewers filter columns
 
     Args:
         df (pd.DataFrame): Original dataframe
+        other (pd.DataFrame): The other (spectrum/fragment) dataframe for coupled filtering
         label (str): used to show filtering options
 
     Returns:
@@ -83,4 +84,8 @@ def filter_dataframe(df: pd.DataFrame, label: str) -> pd.DataFrame:
                 if user_text_input:
                     df = df[df[column].astype(str).str.contains(user_text_input)]
 
-    return df
+    # filter the other dataframe based on spectrum IDs
+    if to_filter_columns:
+        other = other.loc[other.spectrum_id.isin(df.spectrum_id)]
+
+    return df, other

--- a/util/tab2/filter2.py
+++ b/util/tab2/filter2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-## taken from
-## https://blog.streamlit.io/auto-generate-a-dataframe-filtering-ui-in-streamlit-with-filter_dataframe/
+# taken from
+# https://blog.streamlit.io/auto-generate-a-dataframe-filtering-ui-in-streamlit-with-filter_dataframe/
 
 from pandas.api.types import (
     is_categorical_dtype,
@@ -12,19 +12,18 @@ from pandas.api.types import (
 import pandas as pd
 import streamlit as st
 
-def filter_dataframe(df: pd.DataFrame, modify: bool) -> pd.DataFrame:
+
+def filter_dataframe(df: pd.DataFrame, label: str) -> pd.DataFrame:
     """
     Adds a UI on top of a dataframe to let viewers filter columns
 
     Args:
         df (pd.DataFrame): Original dataframe
+        label (str): used to show filtering options
 
     Returns:
         pd.DataFrame: Filtered dataframe
     """
-
-    if not modify:
-        return df
 
     df = df.copy()
 
@@ -42,7 +41,7 @@ def filter_dataframe(df: pd.DataFrame, modify: bool) -> pd.DataFrame:
     modification_container = st.container()
 
     with modification_container:
-        to_filter_columns = st.multiselect("Filter dataframe on", df.columns)
+        to_filter_columns = st.multiselect(f"Filter {label} dataframe on", df.columns)
         for column in to_filter_columns:
             left, right = st.columns((1, 20))
             # Treat columns with < 10 unique values as categorical


### PR DESCRIPTION
This PR aims to unify and streamline filtering options on tab 2, addressing #57 and other issues raised in internal discussion.

Specific tasks:

- [x] make it so that all filtering is configured in one place
- [x] make it so filtering affects both internal dataframes and is reflected in all figures and table previews