### PR TITLE
Temporary fix for #58 and #59, [attempted] fix for #48

### DIFF
--- a/fragannot/fragannot.py
+++ b/fragannot/fragannot.py
@@ -69,9 +69,14 @@ class Fragannot:
         psms = P.read(spectra_file, ident_file, file_format=file_format)
         i = 0
 
-        psms_json = []
+        psms_json = dict()
 
         for psm in psms:
+            psms_json_key = psm.spectrum_id
+            # skip if one psm of the same spectrum has already been done
+            if psms_json_key in psms_json:
+                psms_json[psms_json_key]["nr_idents_with_same_rank"] += 1
+                continue
 
             if (i + 1) % 100 == 0:
                 self.logger.info(f"{i + 1} spectra annotated")
@@ -110,7 +115,7 @@ class Fragannot:
             psm.spectrum["theoretical_code"] = annotation_code
             psm.spectrum["matches_count"] = annotation_count
 
-            psms_json.append(
+            psms_json[psms_json_key] = \
                 {
                     "sequence": psm.peptidoform.sequence,
                     "proforma": psm.peptidoform.proforma,
@@ -118,10 +123,10 @@ class Fragannot:
                     "spectrum_id": psm.spectrum_id,
                     "identification_score": psm.score,
                     "rank": psm.rank,
+                    "nr_idents_with_same_rank": 1,
                     # "precursor_charge": int(psm.get_precursor_charge()),
-                    "precursor_intensity": 666,
+                    "precursor_intensity": 666, # what??
                 }
-            )
             i += 1
 
             # if i == 1000:

--- a/tab1.py
+++ b/tab1.py
@@ -39,6 +39,7 @@ def main(argv = None) -> None:
                                      on_change = reset_spectra,
                                      help = "Upload a spectrum file to be analyzed in .mgf format.")
 
+    w = """
     if spectrum_file is not None:
         with st.status("Reading spectra...") as spectra_reading_status:
             with st_stdout("info"):
@@ -51,7 +52,7 @@ def main(argv = None) -> None:
                         st.session_state["rerun_spectra_reading"] = False
             read_spectra_successfully = st.success("Read all spectra successfully!")
             spectra_reading_status.update(label = f"Read all spectra from file {st.session_state.spectrum_file.name} successfully!", state = "complete")
-
+"""
 
     identifications_file = st.file_uploader("Upload an identification file:",
                                             key = "identifications_file",
@@ -59,6 +60,7 @@ def main(argv = None) -> None:
                                             on_change = reset_identifications,
                                             help = "Upload a identification file that contains PSMs of the spectrum file in .mzid format.")
 
+    w = """
     if identifications_file is not None:
         with st.status("Reading identifications...") as identifications_reading_status:
             with st_stdout("info"):
@@ -71,6 +73,7 @@ def main(argv = None) -> None:
                         st.session_state["rerun_identifications_reading"] = False
             read_identifications_successfully = st.success("Read all identifications successfully!")
             identifications_reading_status.update(label = f"Read all identifications from file {st.session_state.identifications_file.name} successfully!", state = "complete")
+"""
 
     st.session_state["fragannot_call_ion_selection"] = st.session_state["selected_ions_nterm"] + st.session_state["selected_ions_cterm"]
 

--- a/util/converter.py
+++ b/util/converter.py
@@ -117,7 +117,8 @@ class JSONConverter:
                     "prop_intensity_to_base_peak": [],
                     "modification": [],
                     "spectrum_id": [],
-                    "ambiguity": []}
+                    "ambiguity": [],
+                    "nr_idents_with_same_rank": []}
 
         # spectrum-centric dataframe structure
         spectrum = {"perc_internal": [],
@@ -137,9 +138,11 @@ class JSONConverter:
                     "spectrum_id": [],
                     "score": [],
                     "peptide_seq": [],
-                    "peptide_length": []}
+                    "peptide_length": [],
+                    "nr_idents_with_same_rank": []}
 
-        for entry in data:
+        for key in data.keys():
+            entry = data[key]
             pep_seq = entry["sequence"]
             pep_len = len(pep_seq)
 
@@ -164,6 +167,7 @@ class JSONConverter:
                     fragment["modification"].append("")
                     fragment["spectrum_id"].append(self.__get_spectrum_id(entry))
                     fragment["ambiguity"].append(self.__get_ambiguity(entry["annotation"], i))
+                    fragment["nr_idents_with_same_rank"].append(entry["nr_idents_with_same_rank"])
                 else:
                     start, end, ion_cap_start, ion_cap_end, charge, formula = self.__parse_fragment_code(code)
                     frag_seq = pep_seq[start - 1:end]
@@ -184,6 +188,7 @@ class JSONConverter:
                     fragment["modification"].append(self.__parse_modfication(entry["proforma"], start, end))
                     fragment["spectrum_id"].append(self.__get_spectrum_id(entry))
                     fragment["ambiguity"].append(self.__get_ambiguity(entry["annotation"], i))
+                    fragment["nr_idents_with_same_rank"].append(entry["nr_idents_with_same_rank"])
 
             # Spectrum-centric
             percentages_and_total_intensities = self.__calculate_internal_terminal_non_annotated_ions(entry["annotation"]["theoretical_code"], entry["annotation"]["intensity"])
@@ -206,6 +211,7 @@ class JSONConverter:
             spectrum["score"].append(self.__get_identification_score(entry))
             spectrum["peptide_seq"].append(pep_seq)
             spectrum["peptide_length"].append(len(pep_seq))
+            spectrum["nr_idents_with_same_rank"].append(entry["nr_idents_with_same_rank"])
 
         return [pd.DataFrame(fragment), pd.DataFrame(spectrum)]
 


### PR DESCRIPTION
- Removed manual reading of spectrum file and identifications file which is currently only needed for spectrum filtering for "Fraggraph" -> probably discussion point for next meeting how to continue with that (see #58 and #59)
- Removed processing of duplicate/same rank PSMs of the same spectrum_id
  - Only the first PSM per spectrum_id is searched / annotated
  - The number of same rank PSMs is stored in "nr_idents_with_same_rank" (sorry for the lack of a better name, can change this of course)
  - Should resolve #48 if I understood it correctly