### PR TITLE
Streamline spectrum-identifications matching in Spectrumfile

### DIFF
--- a/fragannot/fragannot.py
+++ b/fragannot/fragannot.py
@@ -20,6 +20,7 @@ from ._version import __version__
 from . import constant
 from .parser import Parser as Parser
 
+## ------------------ UNSUPPORTED ---------------------
 
 class Fragannot:
     def __init__(self):

--- a/fragannot/fragannot_call.py
+++ b/fragannot/fragannot_call.py
@@ -17,6 +17,7 @@ def fragannot_call(spectrum_file: BinaryIO,
                    charges: List[str],
                    losses: List[str],
                    deisotope: bool,
+                   parser_pattern: str,
                    file_format: str = "infer",
                    verbose: bool = False) -> Dict:
 
@@ -46,6 +47,7 @@ def fragannot_call(spectrum_file: BinaryIO,
                                               losses,
                                               file_format,
                                               deisotope,
+                                              parser_pattern,
                                               write_file = False)
 
     # remove written files

--- a/fragannot/fragannot_numba.py
+++ b/fragannot/fragannot_numba.py
@@ -40,11 +40,12 @@ class FragannotNumba:
         losses: List[str],
         file_format: str,
         deisotope: bool,
+        parser_pattern: str,
         write_file: bool = True) -> List[Dict[str, Any]]:
 
         return fragment_annotation(ident_file, spectra_file, tolerance,
                                    fragment_types, charges, losses, file_format,
-                                   deisotope, write_file, self.nr_used_cores)
+                                   deisotope, parser_pattern, write_file, self.nr_used_cores)
 
 # set micro batching and batch params here
 def fragment_annotation(
@@ -56,6 +57,7 @@ def fragment_annotation(
     losses: List[str],
     file_format: str,
     deisotope: bool,
+    parser_pattern: str,
     write_file: bool = True,
     nr_used_cores: int = 1,
     micro_batch: bool = True,
@@ -87,7 +89,7 @@ def fragment_annotation(
 
     print("Fragannot running using " + str(nr_used_cores) + " logical cores.\n")
 
-    P = Parser(is_streamlit = True)
+    P = Parser(parser_pattern = parser_pattern, is_streamlit = True)
 
     all_psms = P.read(spectra_file, ident_file, file_format = file_format)
     # construct list of psms with only one psm per spectrum

--- a/fragannot/parser.py
+++ b/fragannot/parser.py
@@ -64,12 +64,13 @@ STANDARD_SEARCHENGINE_SCORES = [
 
 
 class Parser:
-    def __init__(self, is_streamlit: bool = False):
+    def __init__(self, parser_pattern: str, is_streamlit: bool = False):
         # Set up logging
         self.logger = logging.getLogger(__name__)
         self.spectra = None
         self.psm_list = None
         self.is_streamlit = is_streamlit
+        self.parser_pattern = parser_pattern
 
     def read(self, raw_file, ident_file, file_format, max_rank=RANK_LIMIT):
         """Read and process raw file and identification file.
@@ -148,7 +149,7 @@ class Parser:
         file_path : str
             Path to the raw file
         """
-        return SpectrumFile(file_path)
+        return SpectrumFile(file_path, self.parser_pattern)
 
     def __read_id_file(self, file_path, file_format):
         """Read identification file more generously then psm_utils

--- a/fragannot/spectrumfile.py
+++ b/fragannot/spectrumfile.py
@@ -16,7 +16,7 @@ class SpectrumFile:
         self.file_format = None
         self._build_index = None
         self.get_by_id = None
-        self.parser_pattern = pattern
+        self.parser_pattern = parser_pattern
 
         self._load(file_path)
         self._build_index()

--- a/fragannot/spectrumfile.py
+++ b/fragannot/spectrumfile.py
@@ -12,10 +12,19 @@ class SpectrumFile:
         self.file_format = None
         self._build_index = None
         self.get_by_id = None
-        
+
         self._load(file_path)
         self._build_index()
-        
+
+    def __repr_int(self, var: str) -> bool:
+        if type(var) is not str:
+            return False
+        try:
+            int(var)
+        except:
+            return False
+        return True
+
     def _load(self, file_path):
         extension = splitext(file_path)[1]
 
@@ -25,22 +34,24 @@ class SpectrumFile:
             self.file_format = 'mzml'
             self._build_index = self._index_MZML
             self.get_by_id = self._get_by_id_MZML
-            
+
         elif extension.lower() == ".mgf":
             self.logger.info(f"Inferred MGF format from {file_path}")
             self.spectra_source = mgf.IndexedMGF(file_path)
             self.file_format = 'mgf'
             self._build_index = self._index_MGF
             self.get_by_id = self._get_by_id_MGF
-        
+
         else:
             self.logger.info(
                 f"Cannot infer format from {file_path}, only mzML and MGF formats are supported"
             )
             raise Exception("Unsupported spectra file format")
-    
+
     def _get_by_id_MGF(self, id_string):
-        if type(id_string) is int:
+        if type(id_string) is int or self.__repr_int(id_string):
+            if type(id_string) is str:
+                id_string = int(id_string)
             return self.spectra_source.get_by_index(self.indices['scan'][id_string])
         elif type(id_string) is str:
             #in case of whitespaces
@@ -62,12 +73,14 @@ class SpectrumFile:
                     return self.spectra_source.get_by_index(self.indices['scan'][int(id_string)])
 
                 raise KeyError(f'Cannot infer MGF scan from spectrum_id={id_string}')
-                
+
         else:
             raise TypeError(f'Unsupported id type ({type(id_string)}): should be int or string')
 
     def _get_by_id_MZML(self, id_string):
-        if type(id_string) is int:
+        if type(id_string) is int or self.__repr_int(id_string):
+            if type(id_string) is str:
+                id_string = int(id_string)
             return self.spectra_source.get_by_index(self.indices['scan'][id_string])
         elif type(id_string) is str:
             #in case of whitespaces
@@ -89,27 +102,26 @@ class SpectrumFile:
                     return self.spectra_source.get_by_index(self.indices['scan'][int(id_string)])
 
                 raise KeyError(f'Cannot infer MzML scan from spectrum_id={id_string}')
-                
+
         else:
             raise TypeError(f'Unsupported id type ({type(id_string)}): should be int or string')
-    
+
     def _index_MGF(self):
         for index in range(len(self.spectra_source)):
             params = self.spectra_source[index]['params']
             if 'title' in params.keys():
                 self.indices['title'][params['title']] = index
-                
+
             if 'scans' in params.keys():
                 self.indices['scan'][int(params['scans'])] = index
-    
+
     def _index_MZML(self):
         for spectrum in self.spectra_source:
             spectrumID = spectrum['id']
             index = spectrum['index']
-            
+
             scan_match = re.match(r'.+scan(?:\s+)?=(?:\s+)?(\d+)', spectrumID)
-            if not scan_match is None: 
+            if not scan_match is None:
                 self.indices['scan'][int(scan_match.group(1))] = index
-            
+
             self.indices['id'][spectrumID] = index
-       

--- a/fragannot/spectrumfile.py
+++ b/fragannot/spectrumfile.py
@@ -4,14 +4,19 @@ from pyteomics import mzml, mgf
 from os.path import splitext
 from collections import defaultdict
 
+import sys
+sys.path.append("..")
+from util.spectrumio import parse_scannr
+
 class SpectrumFile:
-    def __init__(self, file_path):
+    def __init__(self, file_path, parser_pattern = r'index(?:\s+)?=(?:\s+)?(\d+)'):
         self.logger = logging.getLogger(__name__)
         self.indices = defaultdict(dict)
         self.spectra_source = None
         self.file_format = None
         self._build_index = None
         self.get_by_id = None
+        self.parser_pattern = pattern
 
         self._load(file_path)
         self._build_index()
@@ -61,6 +66,10 @@ class SpectrumFile:
                 return self.spectra_source.get_by_id(id_string)
             except KeyError:
                 #trying to recover
+                scan_nr = parse_scannr(id_string, -1, self.parser_pattern)
+                if scan_nr[0] == 0:
+                    return self.spectra_source.get_by_index(self.indices['scan'][scan_nr[1]])
+
                 match_index = re.match(r'index(?:\s+)?=(?:\s+)?(\d+)', id_string)
 
                 if not match_index is None:
@@ -90,6 +99,10 @@ class SpectrumFile:
                 return self.spectra_source.get_by_id(id_string)
             except KeyError:
                 #trying to recover
+                scan_nr = parse_scannr(id_string, -1, self.parser_pattern)
+                if scan_nr[0] == 0:
+                    return self.spectra_source.get_by_index(self.indices['scan'][scan_nr[1]])
+
                 match_index = re.match(r'index(?:\s+)?=(?:\s+)?(\d+)', id_string)
 
                 if not match_index is None:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,7 +8,7 @@
 #####################################################
 """
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 import pandas as pd
 import streamlit as st

--- a/tab1.py
+++ b/tab1.py
@@ -63,7 +63,7 @@ def main(argv = None) -> None:
                                             type = None, #["mzid"],
                                             on_change = reset_identifications,
                                             help = "Upload a identification file that contains PSMs of the spectrum file in .mzid format.")
-                                            
+
     identifications_file_format = st.selectbox("Select the file format of the identifications file:",
                                                key = "identifications_file_format",
                                                options = SUPPORTED_FILETYPES,
@@ -119,7 +119,10 @@ def main(argv = None) -> None:
                                  use_container_width = True)
 
     if run_analysis:
-        if st.session_state.spectrum_file is not None and st.session_state.identifications_file is not None:
+        cond1 = st.session_state.spectrum_file is not None
+        cond2 = st.session_state.identifications_file is not None
+        cond3 = st.session_state.identifications_file_format is not None
+        if cond1 and cond2 and cond3:
             run_info_title = st.markdown("**Parameters:**")
             run_info_str = f"\tSpectrum file name: {st.session_state.spectrum_file.name}\n" + \
                            f"\tIdentifications file name: {st.session_state.identifications_file.name}\n" + \
@@ -138,7 +141,8 @@ def main(argv = None) -> None:
                                                 st.session_state["fragannot_call_ion_selection"],
                                                 st.session_state["charges"],
                                                 st.session_state["losses"],
-                                                st.session_state.deisotope)
+                                                st.session_state.deisotope,
+                                                st.session_state.identifications_file_format)
                         converter = JSONConverter()
                         st.session_state["result"] = result
                         st.session_state["dataframes"] = converter.to_dataframes(data = result)
@@ -156,7 +160,7 @@ def main(argv = None) -> None:
             else:
                 res_status_1 = st.error("Fragannot stopped prematurely! See log for more information!")
         else:
-            res_status_1 = st.error("You need to specify a spectrum AND identifications file!")
+            res_status_1 = st.error("You need to specify a spectrum AND identifications file AND the file format!")
 
     ############################################################################
     if "dataframes" in st.session_state:

--- a/tab1.py
+++ b/tab1.py
@@ -142,6 +142,7 @@ def main(argv = None) -> None:
                                                 st.session_state["charges"],
                                                 st.session_state["losses"],
                                                 st.session_state.deisotope,
+                                                st.session_state["mgf_parser_pattern"],
                                                 st.session_state.identifications_file_format)
 
                         converter = JSONConverter()


### PR DESCRIPTION
- Handle edge case where the scan number is an integer but encoded as a string
- Parser pattern is now also passed to fragannot for matching spectra and identifications
- fragannot now uses the same `parse_scannr` primarily for matching, but will fall back to its original implementation if that fails

Todo:
- [x] Try to combine the matching from the streamlit interface with fragannot
- [x] Pass regex pattern to parser instead of fixed one

Potential fix for #69 (although the issue might be fixed by using the correct file already)