### PR TITLE
Fix for #83

### DIFF
--- a/internal_ions/tab1.py
+++ b/internal_ions/tab1.py
@@ -43,19 +43,24 @@ def main(argv=None) -> None:
     identifications_file_format = st.selectbox("Select the file format of the identifications file:",
                                                key="identifications_file_format",
                                                options=['infer'] + SUPPORTED_FILETYPES,
-                                               index=None,
+                                               index=0,
                                                placeholder="None selected!",
                                                help="Select the file format of the identifications file, supported options are based on psm_utils.")
 
     if identifications_file is not None and identifications_file_format is not None:
         if "spectrum_file" in st.session_state and st.session_state.spectrum_file is not None:
-            with st.status("Reading identifications...") as identifications_reading_status:
-                psm_list = read_id_file(identifications_file, identifications_file_format)
-                with st_stdout("info"):
-                    if "identifications" not in st.session_state:
-                        st.session_state["identifications"] = read_identifications(psm_list, identifications_file.name, st.session_state.spectrum_file)
-                st.success("Read all identifications successfully!")
-                identifications_reading_status.update(label=f"Read all identifications from file {st.session_state.identifications_file.name} successfully!", state="complete")
+            try:
+                with st.status("Reading identifications...") as identifications_reading_status:
+                    psm_list = read_id_file(identifications_file, identifications_file_format)
+                    with st_stdout("info"):
+                        if "identifications" not in st.session_state:
+                            st.session_state["identifications"] = read_identifications(psm_list, identifications_file.name, st.session_state.spectrum_file)
+                    st.success("Read all identifications successfully!")
+                    identifications_reading_status.update(label=f"Read all identifications from file {st.session_state.identifications_file.name} successfully!", state="complete")
+            except Exception as e:
+                st.warning("Something went wrong! If 'file format = infer' was selected please manually specify file format!", icon="⚠️")
+                with st.expander("Show exception"):
+                    st.exception(e)
         else:
             st.warning("Please upload a spectrum file before the identifications file!", icon="⚠️")
 

--- a/internal_ions/tab1.py
+++ b/internal_ions/tab1.py
@@ -28,10 +28,11 @@ def main(argv=None) -> None:
         type=["mgf"],
         help="Upload a spectrum file to be analyzed in .mgf format.")
 
+    spectrum_file = None
     if uploaded_spectrum_file is not None:
         with st.status("Reading spectra...") as spectra_reading_status:
             with st_stdout("info"):
-                st.session_state.spectrum_file = read_spectrum_file(uploaded_spectrum_file)
+                spectrum_file = read_spectrum_file(uploaded_spectrum_file)
             st.success("Read all spectra successfully!")
             spectra_reading_status.update(label=f"Read all spectra from file {uploaded_spectrum_file.name} successfully!", state="complete")
 
@@ -48,13 +49,13 @@ def main(argv=None) -> None:
                                                help="Select the file format of the identifications file, supported options are based on psm_utils.")
 
     if identifications_file is not None and identifications_file_format is not None:
-        if "spectrum_file" in st.session_state and st.session_state.spectrum_file is not None:
+        if spectrum_file is not None:
             try:
                 with st.status("Reading identifications...") as identifications_reading_status:
                     psm_list = read_id_file(identifications_file, identifications_file_format)
                     with st_stdout("info"):
                         if "identifications" not in st.session_state:
-                            st.session_state["identifications"] = read_identifications(psm_list, identifications_file.name, st.session_state.spectrum_file)
+                            st.session_state["identifications"] = read_identifications(psm_list, identifications_file.name, spectrum_file)
                     st.success("Read all identifications successfully!")
                     identifications_reading_status.update(label=f"Read all identifications from file {st.session_state.identifications_file.name} successfully!", state="complete")
             except Exception as e:
@@ -89,12 +90,12 @@ def main(argv=None) -> None:
                                  use_container_width=True)
 
     if run_analysis:
-        cond1 = st.session_state.spectrum_file is not None
+        cond1 = spectrum_file is not None
         cond2 = st.session_state.identifications_file is not None
         cond3 = st.session_state.identifications_file_format is not None
         if cond1 and cond2 and cond3:
             st.markdown("**Parameters:**")
-            run_info_str = f"\tSpectrum file name: {st.session_state.spectrum_file.name}\n" + \
+            run_info_str = f"\tSpectrum file name: {spectrum_file.name}\n" + \
                            f"\tIdentifications file name: {st.session_state.identifications_file.name}\n" + \
                            f"\tTolerance: {st.session_state.tolerance}\n" + \
                            f"\tSelected ions: {', '.join(st.session_state['fragannot_call_ion_selection'])}\n" + \
@@ -105,7 +106,7 @@ def main(argv=None) -> None:
             with st.status("Fragannot is running! Show logging info:") as st_status:
                 with st_stdout("info"):
                     try:
-                        result = fragannot_call(st.session_state.spectrum_file,
+                        result = fragannot_call(spectrum_file,
                                                 psm_list,
                                                 float(st.session_state.tolerance),
                                                 st.session_state["fragannot_call_ion_selection"],
@@ -116,7 +117,7 @@ def main(argv=None) -> None:
                         converter = JSONConverter()
                         st.session_state["result"] = result
                         st.session_state["dataframes"] = converter.to_dataframes(data=result)
-                        st.session_state["dataframes_source"] = {"spectrum_file": st.session_state.spectrum_file.name,
+                        st.session_state["dataframes_source"] = {"spectrum_file": spectrum_file.name,
                                                                  "identifications_file": st.session_state.identifications_file.name,
                                                                  "fragment_centric_csv": None,
                                                                  "spectrum_centric_csv": None}


### PR DESCRIPTION
- Implemented a fix that the app displays a warning message when no spectrum file is uploaded, instead of crashing
- Reading identifications is not done when no spectrum file is uploaded
- File format is not set by default now, to not accidentally error when the format cannot be inferred