### PR TITLE
Remove initial filtering by ion type

### DIFF
--- a/internal_ions/tab2.py
+++ b/internal_ions/tab2.py
@@ -70,23 +70,9 @@ def main(argv=None) -> None:
             N_ion = st.checkbox("Show non-annotated fragments",
                                 value=False,
                                 help="Whether or not to show non-annotated fragments in the output.")
-            ion_filter_param = [N_ion,
-                                "a" in st.session_state["selected_ions_nterm"],
-                                "b" in st.session_state["selected_ions_nterm"],
-                                "c" in st.session_state["selected_ions_nterm"],
-                                "cdot" in st.session_state["selected_ions_nterm"],
-                                "c-1" in st.session_state["selected_ions_nterm"],
-                                "c+1" in st.session_state["selected_ions_nterm"],
-                                "x" in st.session_state["selected_ions_cterm"],
-                                "y" in st.session_state["selected_ions_cterm"],
-                                False,  # z ions, this is a relict
-                                "zdot" in st.session_state["selected_ions_cterm"],
-                                "z+1" in st.session_state["selected_ions_cterm"],
-                                "z+2" in st.session_state["selected_ions_cterm"],
-                                "z+3" in st.session_state["selected_ions_cterm"]]
 
             st.session_state["frag_center_filtered"], st.session_state["spec_center_filtered"] = filter_dataframes(
-                st.session_state["dataframes"], ion_filter_param)
+                st.session_state["dataframes"], N_ion)
 
             modify = st.checkbox("Filter data", value=False, help="Display filter options")
             if modify:

--- a/internal_ions/util/tab2/filter.py
+++ b/internal_ions/util/tab2/filter.py
@@ -1,26 +1,17 @@
-#!/usr/bin/env python3
-
 import pandas as pd
 from typing import List
 
 
 def filter_dataframes(dataframes: List[pd.DataFrame],
-                      ion_filter: List[bool]) -> List[pd.DataFrame]:
+                      N_ion: bool) -> List[pd.DataFrame]:
     """
-    Filters dataframes based on the given values.
+    Filters non-annotated ions
     """
 
-    ion_filter_translation = ["n", "a", "b", "c", "cdot", "c-1", "c+1", "x", "y", "z", "zdot", "z+1", "z+2", "z+3"]
-    ions_considered = []
+    fragments_df = dataframes[0]
+    spectra_df = dataframes[1]
 
-    for i, val in enumerate(ion_filter):
-        if val:
-            ions_considered.append(ion_filter_translation[i])
-
-    fragments_df = dataframes[0].copy()
-    spectra_df = dataframes[1].copy()
-
-    # filter by ion type
-    fragments_df = fragments_df[fragments_df["frag_code"].str.contains("|".join(ions_considered))]
+    if not N_ion:
+        fragments_df = fragments_df.loc[(fragments_df.frag_type1 != "n") & (fragments_df.frag_type2 != "n")].copy()
 
     return [fragments_df, spectra_df]


### PR DESCRIPTION
This removes initial filtering of the dataframes by ion types, as suggested [here](https://github.com/michabirklbauer/internal_ions/pull/87#issuecomment-2959742093).

If we go with this, perhaps would be nice to somehow disable the widgets in the sidebar after we load the spectrum_centric and fragment_centric files, to avoid confusion. It could actually also make sense to do it in general on tab2 because filtering by ion type is done through other widgets there.