### PR TITLE
Changes in tab3 & merge fraggraphfast optimization

### DIFF
--- a/env.txt
+++ b/env.txt
@@ -68,6 +68,7 @@ Pygments==2.19.1
 pyparsing==3.2.3
 pyright==1.1.400
 pyteomics @ git+https://github.com/levitsky/pyteomics.git@87f39ed373e009dab9ffc3c42589abb8ae2d883d
+pyteomics.cythonize==0.2.9
 python-dateutil==2.9.0.post0
 python-idzip==0.3.9
 pytz==2025.2

--- a/internal_ions/util/psmio.py
+++ b/internal_ions/util/psmio.py
@@ -4,6 +4,7 @@ from psm_utils.io import read_file
 from psm_utils.psm_list import PSMList
 from tempfile import NamedTemporaryFile
 from .spectrumio import SpectrumFile
+import logging
 
 
 @st.cache_data(hash_funcs={PSMList: lambda x: tuple(x.runs), SpectrumFile: lambda x: x.name})
@@ -21,11 +22,16 @@ def read_identifications(psms: PSMList,
         print("Error: Couldn't read identifications file!")
         return {"name": name, "proteins": {}, "peptides": {}}
 
-    proteins_to_scannr = dict()
-    peptides_to_scannr = dict()
-    peptide_to_peptidoforms = dict()
-    proteins_to_peptides = dict()
+    # proteins_to_scannr = dict()
+    peptides_to_scannr = {}
+    peptide_to_peptidoforms = {}
+    peptidoforms_to_scannr = {}
+    # proteins_to_peptides = dict()
     scan_numbers = {spec_id: i for i, spec_id in enumerate(spec_file.index)}
+    for i in scan_numbers:
+        print("Example ID", i)
+        logging.debug("Example ID: %s", i)
+        break
 
     print("Read identifications in total:")
 
@@ -33,31 +39,36 @@ def read_identifications(psms: PSMList,
     for psm in psms:
         peptide = psm.peptidoform.sequence
         scan_nr = scan_numbers[psm.spectrum_id]
+        peptidoform = psm.peptidoform.proforma
         # begin parse necessary information
         # peptides_to_scannr
         if peptide in peptides_to_scannr:
             peptides_to_scannr[peptide].add(scan_nr)
         else:
             peptides_to_scannr[peptide] = {scan_nr}
+        if peptidoform in peptidoforms_to_scannr:
+            peptidoforms_to_scannr[peptidoform].add(scan_nr)
+        else:
+            peptidoforms_to_scannr[peptidoform] = {scan_nr}
         # proteins_to_scannr
-        if psm["protein_list"] is not None:
-            for protein in psm["protein_list"]:
-                if protein in proteins_to_scannr:
-                    proteins_to_scannr[protein].add(scan_nr)
-                else:
-                    proteins_to_scannr[protein] = {scan_nr}
+        # if psm["protein_list"] is not None:
+        #     for protein in psm["protein_list"]:
+        #         if protein in proteins_to_scannr:
+        #             proteins_to_scannr[protein].add(scan_nr)
+        #         else:
+        #             proteins_to_scannr[protein] = {scan_nr}
 
         if peptide in peptide_to_peptidoforms:
             peptide_to_peptidoforms[peptide].add(psm.peptidoform.proforma)
         else:
             peptide_to_peptidoforms[peptide] = {psm.peptidoform.proforma}
         # proteins_to_peptides
-        if psm["protein_list"] is not None:
-            for protein in psm["protein_list"]:
-                if protein in proteins_to_peptides:
-                    proteins_to_peptides[protein].add(peptide)
-                else:
-                    proteins_to_peptides[protein] = {peptide}
+        # if psm["protein_list"] is not None:
+        #     for protein in psm["protein_list"]:
+        #         if protein in proteins_to_peptides:
+        #             proteins_to_peptides[protein].add(peptide)
+        #         else:
+        #             proteins_to_peptides[protein] = {peptide}
         # end parse
         nr_psms += 1
         if nr_psms % 1000 == 0:
@@ -66,11 +77,13 @@ def read_identifications(psms: PSMList,
     print(f"\nFinished reading {nr_psms} identifications!")
 
     return {"name": name,
-            "proteins_to_scannr": proteins_to_scannr,
+            # "proteins_to_scannr": proteins_to_scannr,
             "peptides_to_scannr": peptides_to_scannr,
+            "peptidoforms_to_scannr": peptidoforms_to_scannr,
             # "scannr_to_peptidoforms": scannr_to_peptidoforms,
             "peptide_to_peptidoforms": peptide_to_peptidoforms,
-            "proteins_to_peptides": proteins_to_peptides}
+            # "proteins_to_peptides": proteins_to_peptides
+            }
 
 
 @st.cache_data

--- a/internal_ions/util/spectrumio.py
+++ b/internal_ions/util/spectrumio.py
@@ -100,7 +100,7 @@ def read_spectra(file: SpectrumFile) -> Dict[int, Dict]:
         spectrum_dict = {}
         spectrum_dict["spectrum"] = spectrum
         spectrum_dict["precursor"] = spectrum["params"]["pepmass"]
-        spectrum_dict["charge"] = spectrum["params"]["charge"]
+        spectrum_dict["charge"] = spectrum["params"].get("charge", 0)
         spectrum_dict["rt"] = spectrum["params"].get("rtinseconds", 0.0)
         spectrum_dict["max_intensity"] = float(max(spectrum["intensity array"]))
         peaks = {}

--- a/internal_ions/util/tab3/plots.py
+++ b/internal_ions/util/tab3/plots.py
@@ -35,11 +35,7 @@ def plot_consensus_spectrum(intensity_values, mz_values, coverage) -> go.Figure:
     return fig
 
 
-def plot_spectra_chromatogram(spectra: dict) -> pd.DataFrame:
-    """
-    Returns a DataFrame with the following columns:
-    "scan_nr", "precursor", "charge", "rt", "max_intensity", "peaks"
-    """
+def plot_spectra_chromatogram(spectra: dict):
 
     fig = go.Figure()
 
@@ -47,11 +43,14 @@ def plot_spectra_chromatogram(spectra: dict) -> pd.DataFrame:
     intensity_array = [spectrum["precursor"][1] for spectrum in spectra.values() if spectrum["precursor"][1]]
 
     # if no values, return empty figure
-    if len(intensity_array) <= 0:
-        return fig
+    # if len(intensity_array) <= 0:
+    #     return fig
 
-    min_intensity = min(intensity_array)
-    max_intensity = max(intensity_array)
+    if intensity_array:
+        min_intensity = min(intensity_array)
+        max_intensity = max(intensity_array)
+    else:
+        min_intensity, max_intensity = 0, 1
     print("min/max intensity: ", min_intensity, max_intensity)
     colorscale = [[0, 'blue'], [1, 'red']]  # Define your desired colorscale
 
@@ -61,10 +60,13 @@ def plot_spectra_chromatogram(spectra: dict) -> pd.DataFrame:
         max_intensity = 1
 
     for scan_nr, spectrum in spectra.items():
-        if spectrum["precursor"][1] is None:
-            continue
+        # if spectrum["precursor"][1] is None:
+        #     continue
         intensity = spectrum["precursor"][1]
-        color = (intensity - min_intensity) / (max_intensity - min_intensity)  # Calculate the color value based on intensity
+        if intensity is None:
+            color = 0
+        else:
+            color = (intensity - min_intensity) / (max_intensity - min_intensity)  # Calculate the color value based on intensity
 
         fig.add_trace(go.Scatter(
             x=[spectrum["rt"]],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ streamlit
 numpy
 pandas
 pyteomics
+pyteomics.cythonize
 argparse
 pprintpp
 spectrum_utils


### PR DESCRIPTION
Changes in tab 3:
- select scans by peptide + peptidoform
- allow spectra without precursor intensities

This PR also merges optimizations made by Sabrina for fraggraph.

I was working on trying to get some graphs for middle-down data and I was really missing the possibility to select scans assigned to a specific peptidoform. So I added it instead of protein selection, but we can also keep all three selectors (protein / peptide / peptidoform) for maximum versatility.